### PR TITLE
Potential fix for code scanning alert no. 1: Information exposure through an exception

### DIFF
--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import connections
 from rest_framework.exceptions import NotFound
-
+import logging
 
 def get_model_from_path(database_name: str, model_name: str):
     """
@@ -30,11 +30,14 @@ def get_model_from_path(database_name: str, model_name: str):
     try:
         with connections[database_name].cursor() as cursor:
             cursor.execute("SELECT 1")
+        logger = logging.getLogger(__name__)
+        logger.exception(
+            f"Error connecting to database '{database_name}' in get_model_from_path"
+        )
     except Exception as e:
         raise NotFound(
             f"Cannot connect to database '{database_name}'. "
-            f"The database might not be running or might have connection issues. "
-            f"Error: {str(e)}"
+            "The database might not be running or might have connection issues."
         )
 
     # Get all apps that might contain our model

--- a/apps/core/utils.py
+++ b/apps/core/utils.py
@@ -30,11 +30,11 @@ def get_model_from_path(database_name: str, model_name: str):
     try:
         with connections[database_name].cursor() as cursor:
             cursor.execute("SELECT 1")
+    except Exception as e:
         logger = logging.getLogger(__name__)
         logger.exception(
             f"Error connecting to database '{database_name}' in get_model_from_path"
         )
-    except Exception as e:
         raise NotFound(
             f"Cannot connect to database '{database_name}'. "
             "The database might not be running or might have connection issues."


### PR DESCRIPTION
Potential fix for [https://github.com/jotap1101/dynamic-api/security/code-scanning/1](https://github.com/jotap1101/dynamic-api/security/code-scanning/1)

To fix the issue, we should avoid including internal exception data (`str(e)`) in messages sent to the client. Instead, we should log the detailed error for server-side examination and only include a generic error message in the response. Specifically, in `apps/core/utils.py`, within the `get_model_from_path` function at the `except Exception as e:` clause (lines 33-38), the error should be logged (using Python’s `logging` module or Django's logger), while the raised NotFound message should not leak data from `e`.

**Detailed steps:**
- Import `logging` at the top of the file, if not present.
- In the `except` block, log the full exception info (stack trace) using `logger.exception` or `logging.exception`.
- Change the `raise NotFound(...)` so that no information from `e` is included in the message returned to the client—only a generic "Cannot connect" message with no dynamic error content.

No changes are required elsewhere in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
